### PR TITLE
NOJIRA: fix: updating the makefile go install command for ci, making tests ve…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,10 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go -v test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+ifeq ($(OPENSHIFT_CI), true)
+	hack/publish-codecov.sh
+endif
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.
@@ -244,7 +247,7 @@ set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
 rm -f $(1) || true ;\
-GOBIN=$(LOCALBIN) go install $${package} ;\
+GOBIN=$(LOCALBIN) go install -mod=readonly $${package} ;\
 mv $(1) $(1)-$(3) ;\
 } ;\
 ln -sf $(1)-$(3) $(1)

--- a/hack/publish-codecov.sh
+++ b/hack/publish-codecov.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CI_SERVER_URL=https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test
+COVER_PROFILE=${COVER_PROFILE:-coverage.out}
+JOB_TYPE=${JOB_TYPE:-"local"}
+
+# Configure the git refs and job link based on how the job was triggered via prow
+if [[ "${JOB_TYPE}" == "presubmit" ]]; then
+    echo "detected PR code coverage job for #${PULL_NUMBER}"
+    REF_FLAGS="-P ${PULL_NUMBER} -C ${PULL_PULL_SHA}"
+    JOB_LINK="${CI_SERVER_URL}/pr-logs/pull/${REPO_OWNER}_${REPO_NAME}/${PULL_NUMBER}/${JOB_NAME}/${BUILD_ID}"
+elif [[ "${JOB_TYPE}" == "postsubmit" ]]; then
+    echo "detected branch code coverage job for ${PULL_BASE_REF}"
+    REF_FLAGS="-B ${PULL_BASE_REF} -C ${PULL_BASE_SHA}"
+    JOB_LINK="${CI_SERVER_URL}/logs/${JOB_NAME}/${BUILD_ID}"
+elif [[ "${JOB_TYPE}" == "local" ]]; then
+    echo "coverage report available at ${COVER_PROFILE}"
+    exit 0
+else
+    echo "${JOB_TYPE} jobs not supported" >&2
+    exit 1
+fi
+
+# Configure certain internal codecov variables with values from prow.
+export CI_BUILD_URL="${JOB_LINK}"
+export CI_BUILD_ID="${JOB_NAME}"
+export CI_JOB_ID="${BUILD_ID}"
+
+if [[ "${JOB_TYPE}" != "local" ]]; then
+    if [[ -z "${ARTIFACT_DIR:-}" ]] || [[ ! -d "${ARTIFACT_DIR}" ]] || [[ ! -w "${ARTIFACT_DIR}" ]]; then
+        echo '${ARTIFACT_DIR} must be set for non-local jobs, and must point to a writable directory' >&2
+        exit 1
+    fi
+    curl -sS https://codecov.io/bash -o "${ARTIFACT_DIR}/codecov.sh"
+    bash <(cat "${ARTIFACT_DIR}/codecov.sh") -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+else
+    bash <(curl -s https://codecov.io/bash) -Z -K -f "${COVER_PROFILE}" -r "${REPO_OWNER}/${REPO_NAME}" ${REF_FLAGS}
+fi


### PR DESCRIPTION
Updates:
- Added the verbose flag to `go test` in the makefile
- Added the codecov script call to `make test`
- Added the codecov script to the hack dir for use in CI
- Fixed the `go-install-tool` directive in the makefile to respect vendoring (breaks dependency bin installs in CI)